### PR TITLE
Return URLs (as codes) for posts, and fix issue when ffprobe doesn't know the aspect ratio

### DIFF
--- a/src/handlers/create_image_slideshow.ts
+++ b/src/handlers/create_image_slideshow.ts
@@ -7,6 +7,7 @@ import {
 import HTTP_CLIENT from '../http';
 import {
   Image,
+  LinkablePostPublished,
   LocationSearchRes,
   MediaUploadRes,
   PostPublished,
@@ -31,7 +32,7 @@ async function createImageSlideshowHandler({
   caption: string;
   location?: string;
   verbose: boolean;
-}) {
+}) : Promise<LinkablePostPublished> {
   _validateImages(images);
   validateCaption(caption);
 
@@ -62,9 +63,10 @@ async function createImageSlideshowHandler({
       console.info(
         `[InstagramPublisher] - Image Slideshow Created: ${createSlideshowResponse.status}`
       );
-    return createSlideshowResponse.status === 'ok';
+    return {succeeded: createSlideshowResponse.status === 'ok',
+            code: createSlideshowResponse.media.code};
   }
-  return false;
+  return {succeeded: false, code: ""};
 }
 
 async function _saveSlideshow({

--- a/src/handlers/create_one_image.ts
+++ b/src/handlers/create_one_image.ts
@@ -1,4 +1,9 @@
-import { Image, LocationSearchRes, PostPublished } from '../types';
+import {
+  Image,
+  LinkablePostPublished,
+  LocationSearchRes,
+  PostPublished }
+from '../types';
 import {
   validateCaption,
   validateImageExists,
@@ -22,7 +27,7 @@ async function createSingleImageHandler({
   caption: string;
   verbose: boolean;
   location?: string;
-}): Promise<boolean> {
+}): Promise<LinkablePostPublished> {
   validateCaption(caption);
   validateImageExists(image_path);
 
@@ -95,7 +100,7 @@ async function createSingleImageHandler({
       `[InstagramPublisher] - Image Post Created: ${final_res.status}`
     );
 
-  return final_res.status === 'ok';
+  return {succeeded: final_res.status === 'ok', code: final_res.media.code};
 }
 
 export default createSingleImageHandler;

--- a/src/handlers/create_one_video.ts
+++ b/src/handlers/create_one_video.ts
@@ -54,7 +54,12 @@ async function createSingleVideoHandler({
     'streams'
   ].filter((i: any) => i.codec_type === 'video')[0];
 
-  if (!VALID_VIDEO_ASPECT_RATIOS.find(a => a === display_aspect_ratio)) {
+  // Display Aspect Ratio is frequently listed as N/A in ffprobe, which manifests
+  // as undefined here.
+  const is_display_aspect_ratio_missing = display_aspect_ratio == null;
+
+  if (!is_display_aspect_ratio_missing &&
+      !VALID_VIDEO_ASPECT_RATIOS.find(a => a === display_aspect_ratio)) {
     throw new Error(INVALID_VIDEO_ASPECT_RATIO);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ class InstagramPublisher {
     image_path: string;
     caption: string;
     location?: string;
-  }): Promise<boolean> {
+  }): Promise<object> {
     if (!validateCookies()) {
       await login({
         email: this._email,
@@ -66,7 +66,7 @@ class InstagramPublisher {
     images: string[];
     caption: string;
     location?: string;
-  }): Promise<boolean> {
+  }): Promise<object> {
     if (!validateCookies()) {
       await login({
         email: this._email,
@@ -93,7 +93,7 @@ class InstagramPublisher {
     thumbnail_path: string;
     caption: string;
     location?: string;
-  }): Promise<boolean> {
+  }): Promise<Object> {
     if (!validateCookies()) {
       await login({
         email: this._email,
@@ -123,7 +123,7 @@ class InstagramPublisher {
     thumbnail_path: string;
     caption: string;
     location?: string;
-  }): Promise<boolean> {
+  }): Promise<object> {
     if (!validateCookies()) {
       await login({
         email: this._email,

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,8 +20,18 @@ export interface MediaUploadRes {
   upload_id: string;
 }
 
+export interface MediaUploadRes {
+  code: string;
+}
+
 export interface PostPublished {
   status: string;
+  media: MediaResultFromIG;
+}
+
+export interface LinkablePostPublished {
+  succeeded: boolean;
+  code: string;
 }
 
 export interface Location {


### PR DESCRIPTION
I can add documentation on the README if you think this direction is acceptable.

This pull request addresses two issues I ran into:
1. I need the URL of the instagram reel I just posted (#2)
2. ffprobe doesn't return `display_aspect_ratio` for many videos, including the ones I'm trying to upload.